### PR TITLE
Include elemId to remove operation

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -311,7 +311,8 @@ declare module 'automerge' {
   // text object.
   interface RemoveEdit {
     action: 'remove'
-    opId: OpId      // ID of the operation that removed this value. NOTE: if count > 1 opId is the first operation.
+    opId: OpId      // ID of the operation that removed this value. NOTE: if count > 1 opId is the first operation, but we don't really have edits with count > 1.
+    elemId: OpId    // ID of deleted element. NOTE: if count > 1 opId is the first operation, but we don't really have edits with count > 1.
     index: number   // index of the first list element to remove
     count: number   // number of list elements to remove
   }

--- a/backend/new.js
+++ b/backend/new.js
@@ -1006,7 +1006,7 @@ function updatePatchProperty(patches, newBlock, objectId, op, docState, propStat
       // If the property used to have a non-overwritten/non-deleted value, but no longer, it's a remove
       propState[elemId].action = 'remove'
       const removeOpId = `${op[succCtrIdx]}@${docState.actorIds[op[succActorIdx]]}`
-      appendEdit(patch.edits, {action: 'remove', index: listIndex, count: 1, opId: removeOpId})
+      appendEdit(patch.edits, {action: 'remove', index: listIndex, count: 1, opId: removeOpId, elemId})
       if (newBlock) newBlock.numVisible[objectId] -= 1
     }
 

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -381,7 +381,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'remove', index: 0, count: 1, opId: `3@${actor}`}
+            {action: 'remove', index: 0, count: 1, opId: `3@${actor}`, elemId: `2@${actor}`}
           ]
         }}}}
       })
@@ -404,7 +404,7 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}},
-            {action: 'remove', index: 0, count: 1, opId: `3@${actor}`}
+            {action: 'remove', index: 0, count: 1, opId: `3@${actor}`, elemId: `2@${actor}`}
           ]
         }}}}
       })
@@ -519,7 +519,7 @@ describe('Automerge.Backend', () => {
                 done: {[`4@${actor1}`]: {type: 'value', value: false}}
               }
             }},
-            {action: 'remove', index: 0, count: 1, opId: `5@${actor2}`}
+            {action: 'remove', index: 0, count: 1, opId: `5@${actor2}`, elemId: `2@${actor1}`}
           ]
         }}}}
       })
@@ -711,7 +711,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 9, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'remove', index: 1, count: 3, opId: `7@${actor}`}
+            {action: 'remove', index: 1, count: 3, opId: `7@${actor}`, elemId: `3@${actor}`}
           ]
         }}}}
       })
@@ -883,7 +883,7 @@ describe('Automerge.Backend', () => {
           birds: {'1@111111': {objectId: '1@111111', type: 'list',
             edits: [
               {action: 'insert', index: 0, elemId: '2@111111', opId: '2@111111', value: {type: 'value', value: 'magpie'}},
-              {action: 'remove', index: 0, count: 1, opId: '3@111111'}
+              {action: 'remove', index: 0, count: 1, opId: '3@111111', elemId: '2@111111'}
             ]}}
         }}
       })
@@ -972,7 +972,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [], maxOp: 9, actor, seq: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'remove', index: 1, count: 3, opId: `7@${actor}`}
+            {action: 'remove', index: 1, count: 3, opId: `7@${actor}`, elemId: `3@${actor}`}
           ]
         }}}}
       })

--- a/test/new_backend_test.js
+++ b/test/new_backend_test.js
@@ -620,7 +620,7 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)], pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
-        objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 0, count: 1, opId: `3@${actor}`}]
+        objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 0, count: 1, opId: `3@${actor}`, elemId: `2@${actor}`}]
       }}}}
     })
     checkColumns(backend.blocks[0], {
@@ -672,7 +672,7 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)], pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
-        objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 1, count: 1, opId: `5@${actor}`}]
+        objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 1, count: 1, opId: `5@${actor}`, elemId: `3@${actor}`}]
       }}}}
     })
     checkColumns(backend.blocks[0], {
@@ -1525,7 +1525,7 @@ describe('BackendDoc applying changes', () => {
       diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ['a', 'b']},
-          {action: 'remove', index: 0, count: 1, opId: `4@${actor}`},
+          {action: 'remove', index: 0, count: 1, opId: `4@${actor}`, elemId: `2@${actor}`},
           {action: 'update', index: 0, opId: `5@${actor}`, value: {type: 'value', value: 'x'}}
         ]
       }}}}
@@ -1575,7 +1575,7 @@ describe('BackendDoc applying changes', () => {
           {action: 'insert', index: 0, elemId: `2@${actor1}`, opId: `2@${actor1}`, value: {
             type: 'value', value: 1, datatype: 'uint'
           }},
-          {action: 'remove', index: 0, count: 1, opId: `3@${actor1}`}
+          {action: 'remove', index: 0, count: 1, opId: `3@${actor1}`, elemId: `2@${actor1}`}
         ]
       }}}}
     })
@@ -1976,7 +1976,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     backend.applyChanges([encodeChange(change1)])
     const patch = backend.applyChanges([encodeChange(change2)])
-    assert.deepStrictEqual(patch.diffs.props.text[`1@${actor}`].edits, [{action: 'remove', index: 0, count: MAX_BLOCK_SIZE, opId: `${delStartOp}@${actor}`}])
+    assert.deepStrictEqual(patch.diffs.props.text[`1@${actor}`].edits, [{action: 'remove', index: 0, count: MAX_BLOCK_SIZE, opId: `${delStartOp}@${actor}`, elemId: `${2}@${actor}`}])
     assert.strictEqual(backend.blocks.length, 2)
     const sizeByte1 = 0x80 | 0x7f & (MAX_BLOCK_SIZE / 2), sizeByte2 = (MAX_BLOCK_SIZE / 2) >>> 7
     const firstSucc = MAX_BLOCK_SIZE + 3, secondSucc = MAX_BLOCK_SIZE + 3 + MAX_BLOCK_SIZE / 2


### PR DESCRIPTION
Patch structure for list removes expressed in indices:

```
  interface RemoveEdit {
    action: 'remove'
    opId: OpId      // ID of the operation that removed this value. NOTE: if count > 1 opId is the first operation, but we don't really have edits with count > 1.
    index: number   // index of the first list element to remove
    count: number   // number of list elements to remove
  }
```

Because of that to know _which_ item was deleted we're forced to have index => element id mapping (mostly in a form of [id, id, id] lists). This is clumsy and makes the code harder than it needs to be. 

Here we save `elemId` to RemoveEdit. Notice that it's `elemId` (i.e. id of element in the array, id of the first `make*` operation for that index in the array) not the `objectId` (i.e. id of the last `make*` operation for that index in the array). Since most of our arrays are append-only, it makes more sense. We can add `objectId` later if we'll need to.

After this change, we should be able to get rid of index => element mappings.